### PR TITLE
Create ahk2 script for citation formatting

### DIFF
--- a/case-cite.ahk
+++ b/case-cite.ahk
@@ -6,6 +6,7 @@
 ;   ::<trigger>   -> "/<Case Name>/, <Main reporter cite> (<Court and date>)"  ; no pincite (matches abbrev behavior)
 ;   ::<trigger>sh -> "/<Short case name>/, <Main reporter cite (shortened unless contains WL)> at"
 ;   ::<trigger>n  -> "/<Short case name>/"
+; Immediate insertion: italicizes the Case Name by sending Ctrl+I before and after the name (no slash wrappers).
 
 ^!c:: {
     try {
@@ -16,13 +17,13 @@
         trigger := Prompt("Abbrev trigger:")
         shortCaseName := Prompt("Short case name:")
 
-        ; Build immediate insertion (includes pincite if provided)
-        longCiteInsert := "/" caseName "/, " mainReporter
+        ; Build the tail of the citation (text following the case name)
+        restAfterCase := ", " mainReporter
         if (Trim(pincite) != "")
-            longCiteInsert .= ", " Trim(pincite)
-        longCiteInsert .= " (" courtDate ")"
+            restAfterCase .= ", " Trim(pincite)
+        restAfterCase .= " (" courtDate ")"
 
-        ; Build long-form hotstring text (no pincite, to mirror Emacs abbrev)
+        ; Build long-form hotstring text (no pincite, mirrors Emacs abbrev)
         longCiteAbbrev := "/" caseName "/, " mainReporter " (" courtDate ")"
 
         ; Build short reporter portion: if mainReporter contains "WL", keep as-is;
@@ -52,8 +53,11 @@
         Hotstring("::" . trigger . "sh", shortCite)
         Hotstring("::" . trigger . "n", shortNameText)
 
-        ; Insert the long citation at the caret (with pincite if given)
-        SendText(longCiteInsert)
+        ; Insert the citation at the caret, italicizing the case name via Ctrl+I
+        Send("^i")
+        SendText(caseName)
+        Send("^i")
+        SendText(restAfterCase)
 
         ; Brief confirmation
         ToolTip("Defined hotstrings: " . trigger . ", " . trigger . "sh, " . trigger . "n", , , 1)

--- a/case-cite.ahk
+++ b/case-cite.ahk
@@ -1,0 +1,71 @@
+#Requires AutoHotkey v2.0
+
+; Case citation helper — mirrors Emacs case-cite-skeleton.el
+; Hotkey: Ctrl+Alt+C opens a prompt wizard, inserts the long cite at the caret,
+; and defines three hotstrings:
+;   ::<trigger>   -> "/<Case Name>/, <Main reporter cite> (<Court and date>)"  ; no pincite (matches abbrev behavior)
+;   ::<trigger>sh -> "/<Short case name>/, <Main reporter cite (shortened unless contains WL)> at"
+;   ::<trigger>n  -> "/<Short case name>/"
+
+^!c:: {
+    try {
+        caseName := Prompt("Case Name:")
+        mainReporter := Prompt("Main reporter cite:")
+        pincite := Prompt("Pincite (optional):")
+        courtDate := Prompt("Court and date:")
+        trigger := Prompt("Abbrev trigger:")
+        shortCaseName := Prompt("Short case name:")
+
+        ; Build immediate insertion (includes pincite if provided)
+        longCiteInsert := "/" caseName "/, " mainReporter
+        if (Trim(pincite) != "")
+            longCiteInsert .= ", " Trim(pincite)
+        longCiteInsert .= " (" courtDate ")"
+
+        ; Build long-form hotstring text (no pincite, to mirror Emacs abbrev)
+        longCiteAbbrev := "/" caseName "/, " mainReporter " (" courtDate ")"
+
+        ; Build short reporter portion: if mainReporter contains "WL", keep as-is;
+        ; otherwise drop the last whitespace-separated token (e.g., the page).
+        tokens := StrSplit(mainReporter, " ")
+        hasWL := false
+        for token in tokens {
+            if (token = "WL") {
+                hasWL := true
+                break
+            }
+        }
+        if (!hasWL && tokens.Length > 1) {
+            shortReporter := ""
+            Loop tokens.Length - 1 {
+                shortReporter .= (A_Index = 1 ? "" : " ") . tokens[A_Index]
+            }
+        } else {
+            shortReporter := mainReporter
+        }
+
+        shortCite := "/" shortCaseName "/, " shortReporter " at"
+        shortNameText := "/" shortCaseName "/"
+
+        ; Define dynamic hotstrings
+        Hotstring("::" . trigger, longCiteAbbrev)
+        Hotstring("::" . trigger . "sh", shortCite)
+        Hotstring("::" . trigger . "n", shortNameText)
+
+        ; Insert the long citation at the caret (with pincite if given)
+        SendText(longCiteInsert)
+
+        ; Brief confirmation
+        ToolTip("Defined hotstrings: " . trigger . ", " . trigger . "sh, " . trigger . "n", , , 1)
+        SetTimer(() => ToolTip(), -1500)
+    } catch as err {
+        ; Canceled — do nothing
+    }
+}
+
+Prompt(prompt) {
+    ib := InputBox(prompt, "Case Cite", "w400")
+    if (ib.Result != "OK")
+        throw Error("Canceled")
+    return ib.Value
+}


### PR DESCRIPTION
Add `case-cite.ahk` to replicate Emacs' `case-cite-skeleton.el` functionality for AutoHotkey v2 users.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8599295-74f2-4c33-825d-a3631a1df834">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8599295-74f2-4c33-825d-a3631a1df834">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

